### PR TITLE
include smcsmc and scrm version info, use -v flag to display

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,10 +1,9 @@
 EXTRA_DIST = Doxyfile bootstrap pfpsmc/R/*r pfpsmc/R/ms_vcf.py #acinclude.m4
+SMCSMCVERSION = $(shell git show HEAD | head -1 | sed -e "s/commit //g" | cat)
+SCRMVERSION = $(shell git submodule status | grep scrm | sed -e "s/ //g" -e "s/src.*//" | cat)
 distdir = $(PACKAGE)-$(VERSION)
 #CXXFLAGS= -I/opt/local/include
 #LDFLAGS= -L/opt/local/lib # this is used to link to the unittest library
-
-#include doxygen-include.am
-#include aminclude.am 
 
 bin_PROGRAMS = smcsmc smcsmc_dbg smcsmcRECOMBOFF smcsmcSCRM smcsmcRECOMBOFF_dbg
 #smcsmc_omp smcsmc_dbg smcsmcRECOMBOFF_dbg  smcsmcSCRM
@@ -31,8 +30,7 @@ generate_vcf$(EXEEXT):
 ##exec_unittests: unittests 
 	##./unittests 
 
-
-common_flags = -std=c++0x -O3 -Wall -Wno-unknown-pragmas -Isrc/scrm/src/
+common_flags = -std=c++0x -O3 -Wall -Wno-unknown-pragmas -Isrc/scrm/src/ -DSMCSMCVERSION=\"${SMCSMCVERSION}\" -DSCRMVERSION=\"${SCRMVERSION}\"
 
 # -DNDEBUG  # Define macro NDEBUG, for not showing debug messages
 # -D_RecombRecordingOff # Define macro D_RecombRecordingOff, for turning of Recombevent recorders and recombination rate update

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -55,5 +55,11 @@ void Help_header(){
     cout << "  authored by Sha (Joe) Zhu and Gerton Lunter " <<endl;
     Help_option();
     Help_example();
-    exit(1);
+    exit(0);
 };
+
+void Help_version(string smcsmc, string scrm){
+    cout << "smcsmc: " << smcsmc << endl;
+    cout << "scrm: "   << scrm   << endl;
+    exit(0);
+}

--- a/src/help.hpp
+++ b/src/help.hpp
@@ -29,3 +29,4 @@ using namespace std;
 void Help_option();
 void Help_example();
 void Help_header();
+void Help_version(string smcsmc, string scrm);

--- a/src/pfparam.cpp
+++ b/src/pfparam.cpp
@@ -80,7 +80,13 @@ PfParam::PfParam(int argc, char *argv[]): argc_(argc), argv_(argv) {
         else if (argv_i == "-h" || argv_i == "-help") {
             Help_header();            
             }
-            
+
+        #ifdef SMCSMCVERSION
+        else if (argv_i == "-v") {
+            Help_version(this->smcsmcVersion, this->scrmVersion);
+            }
+        #endif
+
         else {
             scrm_input += argv_i + " ";
             }        
@@ -110,8 +116,20 @@ void PfParam::init(){
     this->default_loci_length = 2e7;
     this->default_num_mut = this->default_mut_rate*40000*this->default_loci_length;
     //this->ghost = 10;
+
+    #ifdef SMCSMCVERSION
+        smcsmcVersion = SMCSMCVERSION;
+    #else
+        smcsmcVersion = "";
+    #endif
     
-    
+
+    #ifdef SCRMVERSION
+        scrmVersion = SCRMVERSION;
+    #else
+        scrmVersion = "";
+    #endif
+
     this->original_recombination_rate_ = 0;
     this->N                = 100;
     //this->buff_length      = 200;

--- a/src/pfparam.hpp
+++ b/src/pfparam.hpp
@@ -56,6 +56,8 @@ class PfParam{
         size_t N;            /*!< \brief Number of particles */
         int    EM_steps;     /*!< \brief Number of EM iterations */
         double ESSthreshold; /*!< \brief Effective sample size, scaled by the number of particles = ESS * N , 0 < ESS < 1 */
+        string smcsmcVersion;
+        string scrmVersion;
 
         // ------------------------------------------------------------------
         // Action 


### PR DESCRIPTION
Using multiple version and submodule starts causing a bit of headache for tracking what we have done. Include commit infos to identify which version of smcsmc was used for testing.

``` bash
$ smcsmc -v
smcsmc: 518c0cb57d57b8cbf7d84f3337fd1e5965e17f44
scrm: 47202c9266494341766205e69be1381d272ced26
```
