### PR TITLE
adding version information to logfile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,7 @@
 EXTRA_DIST = Doxyfile bootstrap pfpsmc/R/*r pfpsmc/R/ms_vcf.py #acinclude.m4
 SMCSMCVERSION = $(shell git show HEAD | head -1 | sed -e "s/commit //g" | cat)
 SCRMVERSION = $(shell git submodule status | grep scrm | sed -e "s/ //g" -e "s/src.*//" | cat)
+COMPILEDATE = $(shell date -u | sed -e "s/ /-/g")
 distdir = $(PACKAGE)-$(VERSION)
 #CXXFLAGS= -I/opt/local/include
 #LDFLAGS= -L/opt/local/lib # this is used to link to the unittest library
@@ -30,7 +31,7 @@ generate_vcf$(EXEEXT):
 ##exec_unittests: unittests 
 	##./unittests 
 
-common_flags = -std=c++0x -O3 -Wall -Wno-unknown-pragmas -Isrc/scrm/src/ -DSMCSMCVERSION=\"${SMCSMCVERSION}\" -DSCRMVERSION=\"${SCRMVERSION}\"
+common_flags = -std=c++0x -O3 -Wall -Wno-unknown-pragmas -Isrc/scrm/src/ -DSMCSMCVERSION=\"${SMCSMCVERSION}\" -DSCRMVERSION=\"${SCRMVERSION}\" -DCOMPILEDATE=\"${COMPILEDATE}\"
 
 # -DNDEBUG  # Define macro NDEBUG, for not showing debug messages
 # -D_RecombRecordingOff # Define macro D_RecombRecordingOff, for turning of Recombevent recorders and recombination rate update

--- a/src/help.cpp
+++ b/src/help.cpp
@@ -37,6 +37,7 @@ void Help_option(){
     cout << setw(10)<<"-online" << setw(5) << " "   << "  --  " << "Perform online EM" << endl;
     cout << setw(10)<<"-log"    << setw(5) << " "   << "  --  " << "Generate *.log file" << endl;
     cout << setw(10)<<"-heat"   << setw(5) << " "   << "  --  " << "Generate *TMRCA and *WEIGHT for heatmap" << endl;
+    cout << setw(10)<<"-v"      << setw(5) << " "   << "  --  " << "Display program compiled time and git versions." << endl;
 };
 
 
@@ -58,8 +59,8 @@ void Help_header(){
     exit(0);
 };
 
-void Help_version(string smcsmc, string scrm){
-    cout << "smcsmc: " << smcsmc << endl;
-    cout << "scrm: "   << scrm   << endl;
-    exit(0);
+void Help_version(string date, string smcsmc, string scrm, std::ostream &output){
+    output << "Program was compiled on: " << date << endl;
+    output << "smcsmc version: " << smcsmc << endl;
+    output << "scrm version: "   << scrm   << endl;
 }

--- a/src/help.hpp
+++ b/src/help.hpp
@@ -24,9 +24,10 @@
 #include <iostream>     /* cout */
 #include <stdlib.h>     /* exit, EXIT_FAILURE */
 #include <iomanip>      // std::setw
+
 using namespace std;
 
 void Help_option();
 void Help_example();
 void Help_header();
-void Help_version(string smcsmc, string scrm);
+void Help_version(string date, string smcsmc, string scrm, std::ostream &output = std::cout);

--- a/src/pfparam.cpp
+++ b/src/pfparam.cpp
@@ -79,21 +79,20 @@ PfParam::PfParam(int argc, char *argv[]): argc_(argc), argv_(argv) {
         
         else if (argv_i == "-h" || argv_i == "-help") {
             Help_header();            
-            }
+        }
 
-        #ifdef SMCSMCVERSION
         else if (argv_i == "-v") {
-            Help_version(this->smcsmcVersion, this->scrmVersion);
-            }
-        #endif
+            Help_version(this->compileTime, this->smcsmcVersion, this->scrmVersion);
+            exit(0);
+        }
 
         else {
             scrm_input += argv_i + " ";
-            }        
-        argc_i++;
         }        
-        this->finalize( );
+        argc_i++;
     }
+    this->finalize( );
+}
 
 
 PfParam::~PfParam(){ 
@@ -117,12 +116,17 @@ void PfParam::init(){
     this->default_num_mut = this->default_mut_rate*40000*this->default_loci_length;
     //this->ghost = 10;
 
+    #ifdef COMPILEDATE
+        compileTime = COMPILEDATE;
+    #else
+        compileTime = "";
+    #endif
+
     #ifdef SMCSMCVERSION
         smcsmcVersion = SMCSMCVERSION;
     #else
         smcsmcVersion = "";
     #endif
-    
 
     #ifdef SCRMVERSION
         scrmVersion = SCRMVERSION;
@@ -291,11 +295,13 @@ int PfParam::log( ){
 
 void PfParam::log_param( ){
     ofstream log_file;
-
     log_file.open (log_NAME.c_str(), ios::out | ios::app | ios::binary); 
-    
+
+    log_file << "###########################\n";
+    log_file << "#        smcsmc log       #\n";
+    log_file << "###########################\n";
+    Help_version(this->compileTime, this->smcsmcVersion, this->scrmVersion, log_file);
     log_file << "smcsmc parameters: \n";
-    
     if (this->heat_bool){
         log_file << "TMRCA saved in file: "  << TMRCA_NAME  << "\n";
         log_file << "WEIGHT saved in file: " << WEIGHT_NAME << "\n";

--- a/src/pfparam.hpp
+++ b/src/pfparam.hpp
@@ -56,8 +56,6 @@ class PfParam{
         size_t N;            /*!< \brief Number of particles */
         int    EM_steps;     /*!< \brief Number of EM iterations */
         double ESSthreshold; /*!< \brief Effective sample size, scaled by the number of particles = ESS * N , 0 < ESS < 1 */
-        string smcsmcVersion;
-        string scrmVersion;
 
         // ------------------------------------------------------------------
         // Action 
@@ -159,6 +157,12 @@ class PfParam{
         string SURVIVOR_NAME;
         int heat_seq_window;
 
+        // ------------------------------------------------------------------
+        // Version Info
+        // ------------------------------------------------------------------
+        string smcsmcVersion;
+        string scrmVersion;
+        string compileTime;
 };
     
 #endif


### PR DESCRIPTION
The output is now, something look like this:

``` bash
$ smcsmc -Np 10
scrm 2 1 -t 8000.000000 -r 800.000000 20000000 
Indirectly called
EM step 0
 Particle filtering step 100% completed.
  Segment data is beyond loci length
 Inference step completed.
 MODEL IS RESET at base 2e+07
 set recombination rate 1.00507e-09(782.4 / 7.78454e+11)
 popsize is equal to 9899.92 ( 1.55112e+07 / 783.4/2)
 check_model_updated_Ne 
Updated Ne at time        0 :  |      9899.92 (       783.4)
Forest state was created 10 times
Forest state destructor was called 0 times
Actual recombination 7824
Actual recomb op is 7.78454e+12
End of EM_step 0
###########################
#        smcsmc log       #
###########################
Program was compiled on: Fri-Mar-27-16:00:31-UTC-2015
smcsmc version: b98e8df8e4c84f6615c17bbc48048611906c8635
scrm version: 47202c9266494341766205e69be1381d272ced26
smcsmc parameters: 
HIST saved in file: pfARGHIST
Ne saved in file: pfARGNe
Segment Data file: empty
     EM steps =         0
            N =        10
          ESS =       0.5 (by default)
scrm model parameters: 
 Extract window =         0
    Random seed =18446744073709551615
    Sample size =         2
     Seq length =  20000000
  mutation rate =     1e-08
    recomb rate =     1e-09
inferred recomb rate = 1.00507e-09
Pop size (at Generation):
  (       0 ) |    9899.92
Actual recombination 7824
```

and 

``` bash
$ smcsmc -v
Program was compiled on: Fri-Mar-27-16:00:31-UTC-2015
smcsmc version: b98e8df8e4c84f6615c17bbc48048611906c8635
scrm version: 47202c9266494341766205e69be1381d272ced26
```
